### PR TITLE
Change th button to inline-flex

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -24,7 +24,7 @@
                 wire:click="sortBy('{{ $column->getColumnSelectName() }}')"
                 {{ 
                     $attributes->merge($customSortButtonAttributes)
-                        ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider group focus:outline-none dark:text-gray-400' => $customSortButtonAttributes['default'] ?? true])
+                        ->class(['inline-flex items-center space-x-1 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider group focus:outline-none dark:text-gray-400' => $customSortButtonAttributes['default'] ?? true])
                         ->except(['default', 'wire:key'])
                 }}
             >


### PR DESCRIPTION
Allow `<th>` column's alignment to change. Eg
```php
->setThAttributes(function(Column $column) {
    if ($column->isField('status')) {
        return [
            'class' => 'text-center',
        ];
    }

    return [];
})```

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
